### PR TITLE
fix npm publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,6 +175,7 @@ jobs:
         uses: actions/setup-node@v2.5.1
         with:
           node-version: "14"
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Npm tool install
         run: npm install -g npm@8
@@ -217,6 +218,7 @@ jobs:
         uses: actions/setup-node@v2.5.1
         with:
           node-version: "14"
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Npm tool install
         run: npm install -g npm@8


### PR DESCRIPTION
add registry url
[doc](https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs#example-using-a-private-registry-and-creating-the-npmrc-file)