### PR TITLE
ApiException from Head Edoc has error message from the response header

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  NPM_VERSION: "1.1.6"
+  NPM_VERSION: "1.1.7"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.7
+
+### Fixes
+- `ApiException` thrown from a HEAD request contains the error message obtained from the response header
+
 ## 1.1.5
 
 ### Features

--- a/lib/ApiException.test.ts
+++ b/lib/ApiException.test.ts
@@ -1,0 +1,52 @@
+import { ProblemDetails } from "./ProblemDetails";
+import { ApiException } from "./ApiException";
+
+describe('ApiException', () => {
+    const statusCode: number = 404;
+    const operationId: string = "123456789";
+
+    test('ApiException returns input problem details', async () => {
+        const problemDetailsTitle: string = "Error: Repository with the given Id not found or no connection could be made."
+        const problemDetails = ProblemDetails.fromJS({
+            "status": statusCode,
+            "title": problemDetailsTitle
+        });
+
+        const apiException = new ApiException("exception message", statusCode, {}, problemDetails);
+
+        expect(apiException.message).toEqual(problemDetailsTitle);
+        expect(apiException.status).toEqual(statusCode);
+        expect(apiException.headers).toEqual({});
+    });
+
+    test('ApiException returns error message from header', async () => {
+        const headers: { [key: string]: any; } = {
+            "x-requestid": operationId,
+            "x-apiserver-error": "Error%3A%20Repository%20with%20the%20given%20Id%20not%20found%20or%20no%20connection%20could%20be%20made."
+        }
+
+        const apiException = new ApiException("exception message", statusCode, headers, null);
+
+        expect(apiException.problemDetails.title).toEqual("Error: Repository with the given Id not found or no connection could be made.");
+        expect(apiException.problemDetails.operationId).toEqual(operationId);
+        expect(apiException.problemDetails.status).toEqual(statusCode);
+        expect(apiException.message).toEqual(apiException.problemDetails.title);
+        expect(apiException.status).toEqual(statusCode);
+        expect(apiException.headers).toEqual(headers);
+    });
+
+    test('ApiException returns default error message', async () => {
+        const headers: { [key: string]: any; } = {
+            "x-requestid": operationId,
+        };
+        const apiException = new ApiException("exception message", statusCode, headers, null);
+
+        expect(apiException.problemDetails.title).toEqual(`HTTP status code ${statusCode}`);
+        expect(apiException.problemDetails.operationId).toEqual(operationId);
+        expect(apiException.problemDetails.status).toEqual(statusCode);
+        expect(apiException.message).toEqual(apiException.problemDetails.title);
+        expect(apiException.status).toEqual(statusCode);
+        expect(apiException.headers).toEqual(headers);
+    });
+});
+  

--- a/lib/ApiException.ts
+++ b/lib/ApiException.ts
@@ -1,5 +1,7 @@
 import { ProblemDetails } from "./ProblemDetails.js";
+
 const OPERATION_ID_HEADER: string = "x-requestid";
+const API_SERVER_ERROR_HEADER: string = "x-apiserver-error";
 
 export class ApiException extends Error  {
     message: string;
@@ -10,14 +12,13 @@ export class ApiException extends Error  {
     constructor(message: string, status: number, headers: { [key: string]: any; }, problemDetails: ProblemDetails | null) {
       super();
 
-      this.message =  message;
-      this.status = status;
-      this.headers = headers;
       this.problemDetails = problemDetails != null && problemDetails.status !== undefined ? problemDetails : ProblemDetails.fromJS({
-        "title": message ?? "HTTP status code " + status,
+        "title": headers[API_SERVER_ERROR_HEADER]? decodeURIComponent(headers[API_SERVER_ERROR_HEADER]) : "HTTP status code " + status,
         "status": status,
         "operationId": headers[OPERATION_ID_HEADER],
       });
+      this.message = this.problemDetails.title?? message;
+      this.status = status;
+      this.headers = headers;
     }
-
   }

--- a/lib/OAuth/TokenClient.test.ts
+++ b/lib/OAuth/TokenClient.test.ts
@@ -48,10 +48,10 @@ describe('getAccessTokenFromServicePrincipal', () => {
     let result: GetAccessTokenResponse = await inst.getAccessTokenFromServicePrincipal(
       testServicePrincipalKey,
       accessKey,
-      "repositories.Read"
+      "repository.Read"
     );
     expect(result?.access_token).toBeTruthy();
-    expect(result?.scope).toBe("repositories.Read");
+    expect(result?.scope).toBe("repository.Read");
   });
 
   test('Correct config with incorrect scope is not included', async () => {
@@ -61,10 +61,10 @@ describe('getAccessTokenFromServicePrincipal', () => {
     let result: GetAccessTokenResponse = await inst.getAccessTokenFromServicePrincipal(
       testServicePrincipalKey,
       accessKey,
-      "repositories.Read invalidScope"
+      "repository.Read invalidScope"
     );
     expect(result?.access_token).toBeTruthy();
-    expect(result?.scope).toBe("repositories.Read");
+    expect(result?.scope).toBe("repository.Read");
   });
 
   // test('Correct config with read specific entry scope', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@laserfiche/lf-api-client-core",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
1. Set the message of the ApiException to the error from the header if no problem details is returned in the body
1. Fixed the scopes in the test
1. Bumped version to 1.1.7